### PR TITLE
Escape setting REPORT_EDITOR_PATH for standalone installs

### DIFF
--- a/assets/installer_install_rivendell.sh
+++ b/assets/installer_install_rivendell.sh
@@ -240,7 +240,7 @@ if test $MODE = "standalone" ; then
     # Create Rivendell Database
     #
     rddbmgr --create --generate-audio
-    echo "update `STATIONS` set `REPORT_EDITOR_PATH`='/usr/bin/gedit'" | mysql -u $MYSQL_LOGINNAME -p$MYSQL_PASSWORD $MYSQL_DATABASE
+    echo update\ \`STATIONS\`\ set\ \`REPORT_EDITOR_PATH\`=\'/usr/bin/gedit\' | mysql -u $MYSQL_LOGINNAME -p$MYSQL_PASSWORD $MYSQL_DATABASE
 
     #
     # Create common directories


### PR DESCRIPTION
The latest RHEL8 RD4 installer finishes with the following error when standalone mode is used:

```
[...]
Complete!
Created symlink /etc/systemd/system/multi-user.target.wants/autofs.service → /usr/lib/systemd/system/autofs.service.
/usr/share/rhel-rivendell-installer/installer_install_rivendell.sh: line 243: STATIONS: command not found
/usr/share/rhel-rivendell-installer/installer_install_rivendell.sh: line 243: REPORT_EDITOR_PATH: command not found
ERROR 1064 (42000) at line 1: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'set ='/usr/bin/gedit'' at line 1

Installation of Rivendell is complete.  Reboot now.
```

This patch brings the stations update command in line with the one ran for server installs, which is already properly escaped. 