### PR TITLE
Ensure `jack2` provides `jack-audio-connection-kit`

### DIFF
--- a/assets/installer_install_rivendell.sh
+++ b/assets/installer_install_rivendell.sh
@@ -107,7 +107,7 @@ wget https://$REPO_HOSTNAME/rhel/8com/Paravel-Commercial.repo -P /etc/yum.repos.
 #
 # Install Dependencies
 #
-dnf -y install patch evince telnet lwmon nc samba paravelview ntpstat emacs twolame-libs libmad nfs-utils cifs-utils samba-client net-tools alsa-utils cups tigervnc-server-minimal pygtk2 cups gedit ntfs-3g ntfsprogs autofs
+dnf -y install patch evince telnet lwmon nc samba paravelview ntpstat emacs twolame-libs libmad nfs-utils cifs-utils samba-client net-tools alsa-utils cups tigervnc-server-minimal pygtk2 cups gedit ntfs-3g ntfsprogs autofs jack2
 
 if test $MODE = "server" ; then
     #


### PR DESCRIPTION
The Rivendell 4 RHEL 8 package depends on JACK, which ends up installing `jack-audio-connection-kit` from EPEL. This is an older version of JACK2 that doesn't play nicely with the promiscuous mode. 

A newer JACK2 package is available in the Paravel repository under the name `jack2`. I'm not exactly sure this is the right way to go about it, but the intention of this patch is to ensure the newer package gets installed in lieu of jack-audio-connection-kit during the Rivendell installation.